### PR TITLE
Update 1-SimulatePurdueNetwork.md

### DIFF
--- a/1-SimulatePurdueNetwork.md
+++ b/1-SimulatePurdueNetwork.md
@@ -157,7 +157,7 @@ As an example, we'll add this [Simulated Temperature Sensor](https://azuremarket
 
 - Choose the **Simulated Temperature Sensor** module from the IoT Edge Module Marketplace page.
 - Click on its name to edit its settings
-- Under *Module Settings*, replace its **imageURI** to `$upstream:443/azureiotedge-simulated-temperature-sensor:1.0`
+- Under *Module Settings*, replace its **imageURI** to `$upstream:443/azureiotedge-simulated-temperature-sensor:latest`
 - Click on **Review+Create** and **Confirm**
 
 An updated deployment is now on-going for `L3-edge` device.


### PR DESCRIPTION
**import_acr.sh** imports the module as **azureiotedge-simulated-temperature-sensor:latest**. Using a **1.0** tag causes the following error:

```
Mar 12 21:52:13 L3-edge aziot-edged[32320]: 2021-03-12T21:52:13Z [INFO] - Pulling image via tag 10.16.6.4:443/azureiotedge-simulated-temperature-sensor:1.0...
Mar 12 21:52:14 L3-edge aziot-edged[32320]: 2021-03-12T21:52:14Z [WARN] - Could not pull image 10.16.6.4:443/azureiotedge-simulated-temperature-sensor:1.0
Mar 12 21:52:14 L3-edge aziot-edged[32320]: 2021-03-12T21:52:14Z [WARN] -         caused by: manifest for 10.16.6.4:443/azureiotedge-simulated-temperature-sensor:1.0 not found: manifest unknown: 
```