### PR TITLE
import 1.0 instead of latest

### DIFF
--- a/scripts/import_acr.sh
+++ b/scripts/import_acr.sh
@@ -90,6 +90,6 @@ az acr import --name $acrName --force --source mcr.microsoft.com/azureiotedge-di
 echo "API proxy..."
 az acr import --name $acrName --force --source mcr.microsoft.com/azureiotedge-api-proxy:latest --image azureiotedge-api-proxy:latest
 echo "Simulated temperature sensor..."
-az acr import --name $acrName --force --source mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:latest --image azureiotedge-simulated-temperature-sensor:latest
+az acr import --name $acrName --force --source mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0 --image azureiotedge-simulated-temperature-sensor:1.0
 echo "...done"
 echo ""


### PR DESCRIPTION
So that simulated temperature sensor image can be added from the marketplace easily.