### PR TITLE
Feature/update lts and squid

### DIFF
--- a/scripts/ARM-templates/iotedgedeploy.json
+++ b/scripts/ARM-templates/iotedgedeploy.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "parameters":
-  {
-    "networkResourceGroupName":
+  "parameters": 
+  {  
+    "networkResourceGroupName": 
     {
       "type": "string",
       "metadata": { "description": "Name of the resource group that the vnet is part of" }
     },
-    "networkName":
+    "networkName": 
     {
       "type": "string",
       "metadata": { "description": "Name of the virtual network IoT Edge VM is deployed to" }
@@ -19,35 +19,35 @@
       "defaultValue": ["7-L5-IT-EnterpriseNetwork", "6-L4-IT-SiteLogistics", "4-L3-OT-SiteOperations"],
       "metadata": { "description": "Name of the subnet IoT Edge VM is deployed to" }
     },
-    "machineNames":
+    "machineNames": 
     {
       "type": "array",
       "defaultValue": ["L5-iotedge", "L4-iotedge", "L3-iotedge"],
       "metadata": { "description": "Name of the IoT Edge VM" }
     },
-    "machineAdminName":
+    "machineAdminName": 
     {
       "type": "string",
       "defaultValue": "iotedgeadmin",
       "metadata": { "description": "Name of the IoT Edge VM administrator" }
     },
-    "machineAdminSshPublicKey":
+    "machineAdminSshPublicKey": 
     {
       "type": "string",
       "metadata": { "description": "SSH public key provided as a string to connect to the IoT Edge VM." }
     },
-    "vmSize":
+    "vmSize": 
     {
       "type": "string",
       "defaultValue": "Standard_DS3_v2",
       "metadata": { "description": "Size of the Azure virtual machine" }
     }
   },
-  "variables":
+  "variables": 
   {
     "location": "[resourceGroup().location]"
   },
-  "resources":
+  "resources": 
   [
     {
       "name": "[concat(parameters('machineNames')[copyIndex()],'-nic-','0')]",
@@ -56,14 +56,14 @@
       "apiVersion": "2018-11-01",
       "dependsOn": [ ],
       "tags": { "displayName": "[concat(parameters('machineNames')[copyIndex()],'-nic-','0')]" },
-      "properties":
+      "properties": 
       {
         "enableAcceleratedNetworking": false,
-        "ipConfigurations":
+        "ipConfigurations": 
 	      [
           {
             "name": "[concat('ipconfig', copyIndex())]",
-            "properties":
+            "properties": 
 	          {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": { "id": "[resourceId(subscription().subscriptionId, parameters('networkResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('networkName'), parameters('subnetNames')[copyIndex()])]" }
@@ -81,21 +81,21 @@
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[variables('location')]",
       "apiVersion": "2018-10-01",
-      "dependsOn":
+      "dependsOn": 
       [
         "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('machineNames')[copyIndex()],'-nic-','0'))]"
       ],
-      "tags":
+      "tags": 
       {
         "displayName": "[parameters('machineNames')[copyIndex()]]"
       },
-      "properties":
+      "properties": 
       {
         "hardwareProfile":
         {
           "vmSize": "[parameters('vmSize')]"
         },
-        "osProfile":
+        "osProfile": 
         {
           "computerName": "[parameters('machineNames')[copyIndex()]]",
           "adminUsername": "[parameters('machineAdminName')]",
@@ -110,23 +110,23 @@
             }
           }
         },
-        "storageProfile":
+        "storageProfile": 
         {
-          "imageReference":
+          "imageReference": 
           {
-            "publisher": "canonical",
-            "offer": "0001-com-ubuntu-server-focal",
-            "sku": "20_04-lts",
+            "publisher": "Canonical",
+            "offer": "UbuntuServer",
+            "sku": "18.04-LTS",
             "version": "latest"
           },
-          "osDisk":
+          "osDisk": 
           {
             "name": "[concat(parameters('machineNames')[copyIndex()],'-disk-','0')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
-          }
+          }          
         },
-        "networkProfile":
+        "networkProfile": 
         {
           "networkInterfaces": [ { "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('machineNames')[copyIndex()],'-nic-','0'))]" } ]
         }
@@ -151,3 +151,4 @@
     }
   }
 }
+  

--- a/scripts/ARM-templates/iotedgedeploy.json
+++ b/scripts/ARM-templates/iotedgedeploy.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "parameters": 
-  {  
-    "networkResourceGroupName": 
+  "parameters":
+  {
+    "networkResourceGroupName":
     {
       "type": "string",
       "metadata": { "description": "Name of the resource group that the vnet is part of" }
     },
-    "networkName": 
+    "networkName":
     {
       "type": "string",
       "metadata": { "description": "Name of the virtual network IoT Edge VM is deployed to" }
@@ -19,35 +19,35 @@
       "defaultValue": ["7-L5-IT-EnterpriseNetwork", "6-L4-IT-SiteLogistics", "4-L3-OT-SiteOperations"],
       "metadata": { "description": "Name of the subnet IoT Edge VM is deployed to" }
     },
-    "machineNames": 
+    "machineNames":
     {
       "type": "array",
       "defaultValue": ["L5-iotedge", "L4-iotedge", "L3-iotedge"],
       "metadata": { "description": "Name of the IoT Edge VM" }
     },
-    "machineAdminName": 
+    "machineAdminName":
     {
       "type": "string",
       "defaultValue": "iotedgeadmin",
       "metadata": { "description": "Name of the IoT Edge VM administrator" }
     },
-    "machineAdminSshPublicKey": 
+    "machineAdminSshPublicKey":
     {
       "type": "string",
       "metadata": { "description": "SSH public key provided as a string to connect to the IoT Edge VM." }
     },
-    "vmSize": 
+    "vmSize":
     {
       "type": "string",
       "defaultValue": "Standard_DS3_v2",
       "metadata": { "description": "Size of the Azure virtual machine" }
     }
   },
-  "variables": 
+  "variables":
   {
     "location": "[resourceGroup().location]"
   },
-  "resources": 
+  "resources":
   [
     {
       "name": "[concat(parameters('machineNames')[copyIndex()],'-nic-','0')]",
@@ -56,14 +56,14 @@
       "apiVersion": "2018-11-01",
       "dependsOn": [ ],
       "tags": { "displayName": "[concat(parameters('machineNames')[copyIndex()],'-nic-','0')]" },
-      "properties": 
+      "properties":
       {
         "enableAcceleratedNetworking": false,
-        "ipConfigurations": 
+        "ipConfigurations":
 	      [
           {
             "name": "[concat('ipconfig', copyIndex())]",
-            "properties": 
+            "properties":
 	          {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": { "id": "[resourceId(subscription().subscriptionId, parameters('networkResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('networkName'), parameters('subnetNames')[copyIndex()])]" }
@@ -81,21 +81,21 @@
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[variables('location')]",
       "apiVersion": "2018-10-01",
-      "dependsOn": 
+      "dependsOn":
       [
         "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('machineNames')[copyIndex()],'-nic-','0'))]"
       ],
-      "tags": 
+      "tags":
       {
         "displayName": "[parameters('machineNames')[copyIndex()]]"
       },
-      "properties": 
+      "properties":
       {
         "hardwareProfile":
         {
           "vmSize": "[parameters('vmSize')]"
         },
-        "osProfile": 
+        "osProfile":
         {
           "computerName": "[parameters('machineNames')[copyIndex()]]",
           "adminUsername": "[parameters('machineAdminName')]",
@@ -110,23 +110,23 @@
             }
           }
         },
-        "storageProfile": 
+        "storageProfile":
         {
-          "imageReference": 
+          "imageReference":
           {
-            "publisher": "Canonical",
-            "offer": "UbuntuServer",
-            "sku": "18.04-LTS",
+            "publisher": "canonical",
+            "offer": "0001-com-ubuntu-server-focal",
+            "sku": "20_04-lts",
             "version": "latest"
           },
-          "osDisk": 
+          "osDisk":
           {
             "name": "[concat(parameters('machineNames')[copyIndex()],'-disk-','0')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
-          }          
+          }
         },
-        "networkProfile": 
+        "networkProfile":
         {
           "networkInterfaces": [ { "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('machineNames')[copyIndex()],'-nic-','0'))]" } ]
         }
@@ -151,4 +151,3 @@
     }
   }
 }
-  

--- a/scripts/ARM-templates/proxydeploy.json
+++ b/scripts/ARM-templates/proxydeploy.json
@@ -1,19 +1,19 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "parameters": 
-  {  
-    "networkResourceGroupName": 
+  "parameters":
+  {
+    "networkResourceGroupName":
     {
       "type": "string",
       "metadata": { "description": "Name of the resource group that the virtual network is part of" }
     },
-    "networkName": 
+    "networkName":
     {
       "type": "string",
       "metadata": { "description": "Name of the virtual network the network VMs are deployed to" }
     },
-    "vmSize": 
+    "vmSize":
     {
       "type": "string",
       "defaultValue": "Standard_DS3_v2",
@@ -24,19 +24,19 @@
       "type": "string",
       "metadata": { "description": "Name of the subnet the IT Proxy is deployed to" }
     },
-    "itProxyMachineName": 
+    "itProxyMachineName":
     {
       "type": "string",
       "defaultValue": "itproxy1",
       "metadata": { "description": "Name of the IT Proxy" }
     },
-    "itProxyMachineAdminName": 
+    "itProxyMachineAdminName":
     {
       "type": "string",
       "defaultValue": "pradmin",
       "metadata": { "description": "Name of the IT Proxy administrator" }
     },
-    "itProxyMachineAdminSshPublicKey": 
+    "itProxyMachineAdminSshPublicKey":
     {
       "type": "string",
       "metadata": { "description": "SSH public key provided as a string to connect to the IT Proxy)" }
@@ -46,25 +46,25 @@
       "type": "string",
       "metadata": { "description": "Name of the subnet the OT Proxy is deployed to" }
     },
-    "otProxyMachineName": 
+    "otProxyMachineName":
     {
       "type": "string",
       "defaultValue": "itproxy1",
       "metadata": { "description": "Name of the OT Proxy" }
     },
-    "otProxyMachineAdminName": 
+    "otProxyMachineAdminName":
     {
       "type": "string",
       "defaultValue": "pradmin",
       "metadata": { "description": "Name of the OT Proxy administrator" }
     },
-    "otProxyMachineAdminSshPublicKey": 
+    "otProxyMachineAdminSshPublicKey":
     {
       "type": "string",
       "metadata": { "description": "SSH public key provided as a string to connect to the OT Proxy." }
     }
   },
-  "variables": 
+  "variables":
   {
     "location": "[resourceGroup().location]",
     "itProxySubnetReference": "[resourceId(subscription().subscriptionId, parameters('networkResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('networkName'), parameters('itProxySubnetName'))]",
@@ -74,7 +74,7 @@
     "otProxyVmNicName": "[concat(parameters('otProxyMachineName'),'-nic-','0')]",
     "otProxyDiskName": "[concat(parameters('otProxyMachineName'),'-disk-','0')]"
   },
-  "resources": 
+  "resources":
   [
     {
       "name": "[variables('itProxyVmNicName')]",
@@ -83,14 +83,14 @@
       "apiVersion": "2018-11-01",
       "dependsOn": [ ],
       "tags": { "displayName": "[variables('itProxyVmNicName')]" },
-      "properties": 
+      "properties":
       {
         "enableAcceleratedNetworking": false,
-        "ipConfigurations": 
+        "ipConfigurations":
 	[
           {
             "name": "ipconfig1",
-            "properties": 
+            "properties":
 	    {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": { "id": "[variables('itProxySubnetReference')]" }
@@ -104,25 +104,25 @@
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[variables('location')]",
       "apiVersion": "2018-10-01",
-      "dependsOn": 
+      "dependsOn":
       [
         "[resourceId('Microsoft.Network/networkInterfaces', variables('itProxyVmNicName'))]"
       ],
-      "tags": 
+      "tags":
       {
         "displayName": "[parameters('itProxyMachineName')]"
       },
-      "properties": 
+      "properties":
       {
         "hardwareProfile":
         {
           "vmSize": "[parameters('vmSize')]"
         },
-        "osProfile": 
+        "osProfile":
         {
           "computerName": "[parameters('itProxyMachineName')]",
           "adminUsername": "[parameters('itProxyMachineAdminName')]",
-          "customData": "[base64(concat('#cloud-config\n\npackage_update: true\npackage_upgrade: true\npackages:\n  - squid3\n  - squid3-client\n  - curl\nwrite_files:\n  - path: /etc/squid/squid.conf\n    owner: root:root\n    permissions: ''0644''\n    content: |\n      # Turn on debug options to allow for monitoring blocked domains\n      debug_options ALL,1 33,2\n\n      dns_v4_first on\n\n      # Squid normally listens to port 3128\n      http_port 3128\n\n      # Setup Most local Network Ranges\n      acl localnet src 10.0.0.0/8  # Possible internal network\n      acl localnet src 172.16.0.0/12 # Possible internal network\n      acl localnet src 192.168.0.0/16 # Possible internal network\n      acl localhost src 127.0.0.1/32 ::1\n\n      acl SSL_ports port 443\n      acl CONNECT method CONNECT\n      acl Safe_ports port 443\n      acl Safe_ports port 80\n\n      acl manager url_regex -i ^cache_object:// +i ^https?://[^/]+/squid-internal-mgr/\n\n      acl whitelist dstdomain \"/etc/squid/whitelist.txt\"\n\n      http_access allow manager localhost\n      http_access deny manager\n      http_access deny !Safe_ports\n\n      http_access deny !whitelist\n\n      http_access allow localhost\n      http_access allow localnet\n\n      http_access deny all\n  - path: /etc/squid/whitelist.txt\n    owner: root:root\n    permissions: ''0644''\n    content: |\n      .ubuntu.com\n      .packages.microsoft.com\n      .docker.io\n      .cloudflare.docker.com\n      .mcr.microsoft.com\n      .azurecr.io\n      .blob.core.windows.net\n      .azure-devices.net\n      .global.azure-devices-provisioning.net\n      .cdn.mscr.io\nruncmd:\n  - |\n      set -x\n      (\n        sudo systemctl daemon-reload\n        sudo systemctl restart squid\n      ) &'))]",
+          "customData": "[base64(concat('#cloud-config\n\npackage_update: true\npackage_upgrade: true\npackages:\n  - squid4\n  - squid4-client\n  - curl\nwrite_files:\n  - path: /etc/squid/squid.conf\n    owner: root:root\n    permissions: ''0644''\n    content: |\n      # Turn on debug options to allow for monitoring blocked domains\n      debug_options ALL,1 33,2\n\n      dns_v4_first on\n\n      # Squid normally listens to port 3128\n      http_port 3128\n\n      # Setup Most local Network Ranges\n      acl localnet src 10.0.0.0/8  # Possible internal network\n      acl localnet src 172.16.0.0/12 # Possible internal network\n      acl localnet src 192.168.0.0/16 # Possible internal network\n      acl localhost src 127.0.0.1/32 ::1\n\n      acl SSL_ports port 443\n      acl CONNECT method CONNECT\n      acl Safe_ports port 443\n      acl Safe_ports port 80\n\n      acl manager url_regex -i ^cache_object:// +i ^https?://[^/]+/squid-internal-mgr/\n\n      acl whitelist dstdomain \"/etc/squid/whitelist.txt\"\n\n      http_access allow manager localhost\n      http_access deny manager\n      http_access deny !Safe_ports\n\n      http_access deny !whitelist\n\n      http_access allow localhost\n      http_access allow localnet\n\n      http_access deny all\n  - path: /etc/squid/whitelist.txt\n    owner: root:root\n    permissions: ''0644''\n    content: |\n      .ubuntu.com\n      .packages.microsoft.com\n      .docker.io\n      .cloudflare.docker.com\n      .mcr.microsoft.com\n      .azurecr.io\n      .blob.core.windows.net\n      .azure-devices.net\n      .global.azure-devices-provisioning.net\n      .cdn.mscr.io\nruncmd:\n  - |\n      set -x\n      (\n        sudo systemctl daemon-reload\n        sudo systemctl restart squid\n      ) &'))]",
           "linuxConfiguration": {
             "disablePasswordAuthentication": true,
             "ssh": {
@@ -133,23 +133,23 @@
             }
           }
         },
-        "storageProfile": 
+        "storageProfile":
         {
-          "imageReference": 
+          "imageReference":
           {
-            "publisher": "Canonical",
-            "offer": "UbuntuServer",
-            "sku": "18.04-LTS",
+            "publisher": "canonical",
+            "offer": "0001-com-ubuntu-server-focal",
+            "sku": "20_04-lts",
             "version": "latest"
           },
-          "osDisk": 
+          "osDisk":
           {
             "name": "[variables('itProxyDiskName')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
-          }          
+          }
         },
-        "networkProfile": 
+        "networkProfile":
         {
           "networkInterfaces": [ { "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('itProxyVmNicName'))]" } ]
         }
@@ -162,14 +162,14 @@
       "apiVersion": "2018-11-01",
       "dependsOn": [ ],
       "tags": { "displayName": "[variables('otProxyVmNicName')]" },
-      "properties": 
+      "properties":
       {
         "enableAcceleratedNetworking": false,
-        "ipConfigurations": 
+        "ipConfigurations":
 	[
           {
             "name": "ipconfig1",
-            "properties": 
+            "properties":
 	    {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": { "id": "[variables('otProxySubnetReference')]" }
@@ -183,25 +183,25 @@
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[variables('location')]",
       "apiVersion": "2018-10-01",
-      "dependsOn": 
+      "dependsOn":
       [
         "[resourceId('Microsoft.Network/networkInterfaces', variables('otProxyVmNicName'))]"
       ],
-      "tags": 
+      "tags":
       {
         "displayName": "[parameters('otProxyMachineName')]"
       },
-      "properties": 
+      "properties":
       {
         "hardwareProfile":
         {
           "vmSize": "[parameters('vmSize')]"
         },
-        "osProfile": 
+        "osProfile":
         {
           "computerName": "[parameters('otProxyMachineName')]",
           "adminUsername": "[parameters('otProxyMachineAdminName')]",
-          "customData": "[base64(concat('#cloud-config\n\npackage_update: true\npackage_upgrade: true\npackages:\n  - squid3\n  - squid3-client\n  - curl\nwrite_files:\n  - path: /etc/squid/squid.conf\n    owner: root:root\n    permissions: ''0644''\n    content: |\n      # Turn on debug options to allow for monitoring blocked domains\n      debug_options ALL,1 33,2\n\n      dns_v4_first on\n\n      # Squid normally listens to port 3128\n      http_port 3128\n\n      # allow all requests\n      http_access allow all\n\n  - path: /etc/squid/whitelist.txt\n    owner: root:root\n    permissions: ''0644''\n    content: |\n      .com\n      .io\n      .net\n      .io\nruncmd:\n  - |\n      set -x\n      (\n        sudo systemctl daemon-reload\n        sudo systemctl restart squid\n      ) &'))]",
+          "customData": "[base64(concat('#cloud-config\n\npackage_update: true\npackage_upgrade: true\npackages:\n  - squid4\n  - squid4-client\n  - curl\nwrite_files:\n  - path: /etc/squid/squid.conf\n    owner: root:root\n    permissions: ''0644''\n    content: |\n      # Turn on debug options to allow for monitoring blocked domains\n      debug_options ALL,1 33,2\n\n      dns_v4_first on\n\n      # Squid normally listens to port 3128\n      http_port 3128\n\n      # allow all requests\n      http_access allow all\n\n  - path: /etc/squid/whitelist.txt\n    owner: root:root\n    permissions: ''0644''\n    content: |\n      .com\n      .io\n      .net\n      .io\nruncmd:\n  - |\n      set -x\n      (\n        sudo systemctl daemon-reload\n        sudo systemctl restart squid\n      ) &'))]",
           "linuxConfiguration": {
             "disablePasswordAuthentication": true,
             "ssh": {
@@ -212,37 +212,36 @@
             }
           }
         },
-        "storageProfile": 
+        "storageProfile":
         {
-          "imageReference": 
+          "imageReference":
           {
-            "publisher": "Canonical",
-            "offer": "UbuntuServer",
-            "sku": "18.04-LTS",
+            "publisher": "canonical",
+            "offer": "0001-com-ubuntu-server-focal",
+            "sku": "20_04-lts",
             "version": "latest"
           },
-          "osDisk": 
+          "osDisk":
           {
             "name": "[variables('otProxyDiskName')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
-          }          
+          }
         },
-        "networkProfile": 
+        "networkProfile":
         {
           "networkInterfaces": [ { "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('otProxyVmNicName'))]" } ]
         }
       }
     }
   ],
-  "outputs": 
+  "outputs":
   {
     "itProxyMachineName": { "type": "string", "value": "[parameters('itProxyMachineName')]" },
     "itProxyPrivateIpAddress": { "value": "[reference(variables('itProxyVmNicName')).ipConfigurations[0].properties.privateIPAddress]", "type": "string" },
     "itProxyAdminUsername": { "type": "string", "value": "[parameters('itProxyMachineAdminName')]" },
     "otProxyMachineName": { "type": "string", "value": "[parameters('otProxyMachineName')]" },
     "otProxyPrivateIpAddress": { "value": "[reference(variables('otProxyVmNicName')).ipConfigurations[0].properties.privateIPAddress]", "type": "string" },
-    "otProxyAdminUsername": { "type": "string", "value": "[parameters('otProxyMachineAdminName')]" } 
+    "otProxyAdminUsername": { "type": "string", "value": "[parameters('otProxyMachineAdminName')]" }
   }
 }
-  

--- a/scripts/cloud-inits/itsquid/cloud-init.txt
+++ b/scripts/cloud-inits/itsquid/cloud-init.txt
@@ -3,8 +3,8 @@
 package_update: true
 package_upgrade: true
 packages:
-  - squid3
-  - squid3-client
+  - squid4
+  - squid4-client
   - curl
 write_files:
   - path: /etc/squid/squid.conf

--- a/scripts/cloud-inits/otsquid/cloud-init.txt
+++ b/scripts/cloud-inits/otsquid/cloud-init.txt
@@ -3,8 +3,8 @@
 package_update: true
 package_upgrade: true
 packages:
-  - squid3
-  - squid3-client
+  - squid4
+  - squid4-client
   - curl
 write_files:
   - path: /etc/squid/squid.conf


### PR DESCRIPTION
This does two things:
1. Updates the image to 20.04
2. Updates squid from 3 to 4

The change in image is a requirement for the latest squid version.

TODO:
- [x] Manually verify deployment and that squid version is correct and traffic can still flow through fine.